### PR TITLE
ROCANA-7833: sarama throttles reconnects to unavailable brokers

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"github.com/scalingdata/errors"
 	"io"
+	"math/rand"
 	"net"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -17,12 +17,13 @@ type Broker struct {
 	id   int32
 	addr string
 
-	conf          *Config
-	correlationID int32
-	conn          net.Conn
-	connErr       error
-	lock          sync.Mutex
-	opened        int32
+	conf           *Config
+	correlationID  int32
+	conn           net.Conn
+	connErr        error
+	retryAfter     time.Time
+	currentBackoff time.Duration
+	lock           sync.Mutex
 
 	responses chan responsePromise
 	done      chan bool
@@ -55,20 +56,22 @@ func (b *Broker) Open(conf *Config) error {
 		return err
 	}
 
-	if !atomic.CompareAndSwapInt32(&b.opened, 0, 1) {
-		return ErrAlreadyConnected
-	}
-
 	b.lock.Lock()
-
-	if b.conn != nil {
-		b.lock.Unlock()
-		Logger.Printf("Failed to connect to broker %s: %s\n", b.addr, ErrAlreadyConnected)
-		return ErrAlreadyConnected
-	}
 
 	go withRecover(func() {
 		defer b.lock.Unlock()
+
+		// Abort the connection attempt if we're connected by the time we obtain the lock
+		if b.conn != nil {
+			return
+		}
+
+		// Abort this connection attempt if sarama has penalized the broker due to
+		// previous failed connection attempts
+		now := time.Now()
+		if !b.retryAfter.IsZero() && (now.Before(b.retryAfter) || now.Equal(b.retryAfter)) {
+			return
+		}
 
 		dialer := net.Dialer{
 			Timeout:   conf.Net.DialTimeout,
@@ -83,11 +86,12 @@ func (b *Broker) Open(conf *Config) error {
 		if b.connErr != nil {
 			b.connErr = errors.New(b.connErr)
 			b.conn = nil
-			atomic.StoreInt32(&b.opened, 0)
+			b.advanceBackoff(conf)
 			Logger.Printf("Failed to connect to broker %s: %s\n", b.addr, b.connErr)
 			return
 		}
 		b.conn = newBufConn(b.conn)
+		b.resetBackoff()
 
 		b.conf = conf
 		b.done = make(chan bool)
@@ -130,8 +134,6 @@ func (b *Broker) Close() error {
 	b.connErr = nil
 	b.done = nil
 	b.responses = nil
-
-	atomic.StoreInt32(&b.opened, 0)
 
 	if err == nil {
 		Logger.Printf("Closed connection to broker %s\n", b.addr)
@@ -461,4 +463,53 @@ func (b *Broker) responseReceiver() {
 		response.packets <- buf
 	}
 	close(b.done)
+}
+
+func (b *Broker) Penalized() bool {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	now := time.Now()
+	if !b.retryAfter.IsZero() && (now.Before(b.retryAfter) || now.Equal(b.retryAfter)) {
+		return true
+	}
+	return false
+}
+
+// Reset backoff to its initial state. The broker lock should be held when calling
+// this method.
+func (b *Broker) resetBackoff() {
+	b.currentBackoff = time.Second
+	var t time.Time
+	b.retryAfter = t
+}
+
+// Advance backoff to its next state. The broker lock should be held when calling
+// this method.
+func (b *Broker) advanceBackoff(conf *Config) {
+	var adj time.Duration
+	if b.currentBackoff < conf.Net.Backoff.Initial {
+		b.currentBackoff = conf.Net.Backoff.Initial
+		adj = conf.Net.Backoff.Initial
+	} else if b.currentBackoff >= conf.Net.Backoff.Max {
+		b.currentBackoff = conf.Net.Backoff.Max
+		adj = conf.Net.Backoff.Max
+	} else {
+		// Calculate the next backoff
+		backoff := int64(float64(b.currentBackoff) * conf.Net.Backoff.Multiplier)
+		if backoff > int64(conf.Net.Backoff.Max) {
+			backoff = int64(conf.Net.Backoff.Max)
+		}
+		maxJitter := int64(float64(backoff) * conf.Net.Backoff.Jitter)
+		jitter := rand.Int63n(maxJitter)
+		if jitter%2 == 0 {
+			jitter = -1 * jitter
+		}
+		adj = time.Duration(backoff + jitter)
+		b.currentBackoff = time.Duration(backoff)
+	}
+
+	Logger.Printf("Waiting %v seconds before attempting reconnect to broker %s", adj, b.addr)
+	now := time.Now()
+	b.retryAfter = now.Add(adj)
 }

--- a/client.go
+++ b/client.go
@@ -132,8 +132,13 @@ func NewClient(addrs []string, conf *Config) (Client, error) {
 		client.seedBrokers = append(client.seedBrokers, NewBroker(addrs[index]))
 	}
 
+	isConnected, err := client.waitForSingleConnection()
+	if isConnected == false {
+		return nil, ErrOutOfBrokers
+	}
+
 	// do an initial fetch of all cluster metadata by specifing an empty list of topics
-	err := client.RefreshMetadata()
+	err = client.RefreshMetadata()
 	switch err {
 	case nil:
 		break
@@ -421,13 +426,46 @@ func (client *client) resurrectDeadBrokers() {
 	client.deadSeeds = nil
 }
 
+func (client *client) waitForSingleConnection() (bool, error) {
+	// Attempt to connect to each broker asynchronously. Any returned Open() errors
+	// should be ConfigurationError
+	for _, broker := range client.seedBrokers {
+		err := broker.Open(client.conf)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	// Determine if at least one successfully connected
+	brokerErrs := make(map[int]error)
+	for {
+		for i, broker := range client.seedBrokers {
+			isConnected, err := broker.Connected()
+			if isConnected {
+				return true, nil
+			}
+			if err != nil {
+				brokerErrs[i] = err
+			}
+		}
+		if len(brokerErrs) == len(client.seedBrokers) {
+			break
+		}
+		time.Sleep(time.Millisecond) // avoid a tight loop
+	}
+
+	return false, nil
+}
+
 func (client *client) any() *Broker {
 	client.lock.RLock()
 	defer client.lock.RUnlock()
 
-	if len(client.seedBrokers) > 0 {
-		_ = client.seedBrokers[0].Open(client.conf)
-		return client.seedBrokers[0]
+	for _, broker := range client.seedBrokers {
+		if !broker.Penalized() {
+			_ = broker.Open(client.conf)
+			return broker
+		}
 	}
 
 	// not guaranteed to be random *or* deterministic
@@ -580,6 +618,11 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int)
 			return client.tryRefreshMetadata(topics, attemptsRemaining-1)
 		}
 		return err
+	}
+
+	isConnected, _ := client.waitForSingleConnection()
+	if !isConnected {
+		return ErrOutOfBrokers
 	}
 
 	for broker := client.any(); broker != nil; broker = client.any() {

--- a/config.go
+++ b/config.go
@@ -33,6 +33,16 @@ type Config struct {
 		// KeepAlive specifies the keep-alive period for an active network connection.
 		// If zero, keep-alives are disabled. (default is 0: disabled).
 		KeepAlive time.Duration
+
+		// Connection backoff settings when a broker is unavailable.
+		// Modeled after gRPC Connection Backoff Protocol:
+		// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
+		Backoff struct {
+			Initial    time.Duration // How long to wait after the first failure before retrying
+			Multiplier float64       // Factor with which to multiply backoff after a failed retry
+			Jitter     float64       // Factor to vary connection attempts
+			Max        time.Duration // Maximum amount of time to wait before retry
+		}
 	}
 
 	// Metadata is the namespace for metadata management properties used by the
@@ -213,6 +223,11 @@ func NewConfig() *Config {
 	c.Net.ReadTimeout = 30 * time.Second
 	c.Net.WriteTimeout = 30 * time.Second
 
+	c.Net.Backoff.Initial = 1 * time.Second
+	c.Net.Backoff.Multiplier = 1.6
+	c.Net.Backoff.Jitter = 0.2
+	c.Net.Backoff.Max = 120 * time.Second
+
 	c.Metadata.Retry.Max = 3
 	c.Metadata.Retry.Backoff = 250 * time.Millisecond
 	c.Metadata.RefreshFrequency = 10 * time.Minute
@@ -283,6 +298,16 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Net.WriteTimeout must be > 0")
 	case c.Net.KeepAlive < 0:
 		return ConfigurationError("Net.KeepAlive must be >= 0")
+	case c.Net.Backoff.Initial < 0:
+		return ConfigurationError("Net.Backoff.Initial must be >= 0")
+	case c.Net.Backoff.Multiplier < 0:
+		return ConfigurationError("Net.Backoff.Multiplier must be >= 0")
+	case c.Net.Backoff.Jitter < 0:
+		return ConfigurationError("Net.Backoff.Jitter must be >= 0")
+	case c.Net.Backoff.Max < 0:
+		return ConfigurationError("Net.Backoff.Max must be >= 0")
+	case c.Net.Backoff.Max < c.Net.Backoff.Initial:
+		return ConfigurationError("Net.Backoff.Max must be greater than Net.Backoff.Initial")
 	}
 
 	// validate the Metadata values


### PR DESCRIPTION
This PR reworks how sarama performs connection attempts to kafka brokers by introducing an exponential backoff delay between attempts. The algorithm is modeled off the <a href="https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md">gRPC connection backoff protocol</a>. 

Sarama uses an asynchronous `broker.Open()` method. `Open()` will validate the config and given a valid config will return immediately (never blocking on network IO), spawning a goroutine to establish the connection. Multiple `Open()`s may be in flight at once, so the `broker` struct members are protected with a lock.

`Open()` requests tend to be tied to actions the client is taking like requested metadata updates - there is no persistent thread that attempts to maintain connections with all brokers. The upside to the design is one can say "be sure this broker is open" and continue without much additional thought to the state of the broker.

The meat of the exponential backoff algorithm starts in the goroutine spawned by `broker.Open()`. If a connection attempt fails for any reason, the broker will be "penalized" and future connection attempts before this penalty has expired will be dropped. Because `Open()` requests are based on actions taken by sarama, the backoff penalty applied from the user's perspective is a minimum bound. A connection attempt may not be reattempted immediately after the penalty expires.

Other changes include:
* `broker.Open()` no longer returns `ErrAlreadyConnected`. This was really confusing when tracing the code (did an error occur or were we already connected?), and no sarama code special cases this error value.
* Removal of the broker's `opened` struct member. This is no longer needed because `ErrAlreadyConnected` is no longer returned.
* At startup, a new sarama client synchronously waits for at least a single broker to be available. This is effectively the same as sarama's previous behavior, but now ensures we don't retry the metadata refresh unless we've successfully created a broker connection. Without this fix, there is a race condition where retries will begin before we've finished the initial connection, and turning off metadata retries will prevent sarama from connecting to a healthy kafka cluster.