### PR TITLE
ROCANA-7866: Kafka producer blocks shutdown when some partitions are leaderless

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -434,7 +434,6 @@ func (pp *partitionProducer) dispatch() {
 		if pp.output == nil {
 			if err := pp.updateLeader(); err != nil {
 				pp.parent.returnError(msg, err)
-				time.Sleep(pp.parent.conf.Producer.Retry.Backoff)
 				continue
 			}
 			Logger.Printf("producer/leader/%s/%d selected broker %d\n", pp.topic, pp.partition, pp.leader.ID())


### PR DESCRIPTION
EDIT: for background, see the <a href="https://github.com/Shopify/sarama/wiki/Producer-implementation">producer implementation wiki page</a>

When at least one partition is leaderless, sarama's partition producer will attempt to update its partition leader metadata each message. If this fails (where failure includes the partition still being leaderless), sarama will sleep for the backoff period (defaults to 100ms) before attempting to send the next message. Unfortunately this causes the shutdown routine to block for long periods of time during shutdown if messages are caught in the partition producer. There is no mechanism for the partition producer to know that shutdown is in-progress, so this queue is drained at a very slow rate.

This PR removes the sleep performed after each message to expedite the shutdown and overall failure processes. If a message is in-flight when the partition becomes leaderless, it will be shuffled off to another partition quickly rather than having to wait number of messages queued * the backoff period. By removing the sleep, the delay is much reduced and messages aren't unnecessarily held in the failed partition producer when they can be sent to other partitions without issue.

The partition producer will still sleep the backoff period each time the retry level reaches a new high water mark, so in the case of using the hash partitioner (which requires messages to be sent on a specific partition), the failures will occur more quickly but still introduces a reasonable delay so that all retries aren't exhausted immediately.