### PR TITLE
Client can't recover from broker outages

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -325,6 +325,9 @@ func (tp *topicProducer) partitionMessage(msg *ProducerMessage) error {
 		} else {
 			partitions, err = tp.parent.client.WritablePartitions(msg.Topic)
 		}
+		if (err != nil) {
+			Logger.Printf("Failed to get partition list for topic %v", msg.Topic)
+		}
 		return
 	})
 
@@ -495,10 +498,12 @@ func (pp *partitionProducer) flushRetryBuffers() {
 func (pp *partitionProducer) updateLeader() error {
 	return pp.breaker.Run(func() (err error) {
 		if err = pp.parent.client.RefreshMetadata(pp.topic); err != nil {
+			Logger.Printf("Failed to refresh metadata for partition producer on topic %v - %v", pp.topic, err)
 			return err
 		}
 
 		if pp.leader, err = pp.parent.client.Leader(pp.topic, pp.partition); err != nil {
+			Logger.Printf("Failed to get leader for partition producer on topic %v - %v", pp.topic, err)
 			return err
 		}
 

--- a/broker.go
+++ b/broker.go
@@ -56,19 +56,23 @@ func (b *Broker) Open(conf *Config) error {
 		return err
 	}
 
+	Logger.Printf("Acquiring open lock for broker %v", b.addr)
 	b.lock.Lock()
+	Logger.Printf("Acquired open lock for broker %v", b.addr)
 
 	go withRecover(func() {
 		defer b.lock.Unlock()
 
 		// Abort the connection attempt if we're connected by the time we obtain the lock
 		if b.conn != nil {
+			Logger.Printf("Broker is already connected, short-circuited open %v", b.addr)
 			return
 		}
 
 		// Abort this connection attempt if sarama has penalized the broker due to
 		// previous failed connection attempts
 		if b.penalized() {
+			Logger.Printf("Broker is penalized, failed to open %v", b.addr)
 			return
 		}
 

--- a/client.go
+++ b/client.go
@@ -621,12 +621,6 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int)
 		return err
 	}
 
-        isConnected, _ := client.waitForSingleConnection()
-        if !isConnected {
-                return ErrOutOfBrokers
-        }
-
-
 	for broker := client.any(); broker != nil; broker = client.any() {
 		if len(topics) > 0 {
 			Logger.Printf("client/metadata fetching metadata for %v from broker %s\n", topics, broker.addr)

--- a/client.go
+++ b/client.go
@@ -429,6 +429,7 @@ func (client *client) resurrectDeadBrokers() {
 func (client *client) waitForSingleConnection() (bool, error) {
 	// Attempt to connect to each broker asynchronously. Any returned Open() errors
 	// should be ConfigurationError
+	Logger.Printf("Number of seed brokers: %v", len(client.seedBrokers))
 	for _, broker := range client.seedBrokers {
 		err := broker.Open(client.conf)
 		if err != nil {
@@ -620,10 +621,11 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int)
 		return err
 	}
 
-	isConnected, _ := client.waitForSingleConnection()
-	if !isConnected {
-		return ErrOutOfBrokers
-	}
+        isConnected, _ := client.waitForSingleConnection()
+        if !isConnected {
+                return ErrOutOfBrokers
+        }
+
 
 	for broker := client.any(); broker != nil; broker = client.any() {
 		if len(topics) > 0 {


### PR DESCRIPTION
This adds a bunch of useful logging to understand how brokers are penalized. 

The root cause was:
- `waitForSingleConnection` only uses the list of seed brokers
- in `tryRefreshMetadata` if `waitForSingleConnection` fails, we short-circuit the whole method, which means we never call `resurrectDeadBrokers`

On a heavily loaded producer there was a race condition where the set of seed brokers could be empty, and all the calls to `tryRefreshMetadata` would fail forever. The solution was to ensure we always resurrect the seed brokers if the broker list becomes empty.